### PR TITLE
Removed browser option from rollup build (Vue)

### DIFF
--- a/packages/vue/src/rollup.config.js
+++ b/packages/vue/src/rollup.config.js
@@ -5,7 +5,7 @@ import commonjs from 'rollup-plugin-commonjs'
 export default {
   input: 'packages/vue/dist/index.js',
   plugins: [
-    resolve({ browser: true }),
+    resolve(),
     uglify(),
     commonjs()
   ],


### PR DESCRIPTION
Looks like you don’t need this option, because you have no option `browser` in your package.json.

> Some package.json files have a `browser` field which specifies alternative files to load for people bundling for the browser. If that's you, use this option, otherwise `pkg.browser` will be ignored.

Default: `false`

Source: https://github.com/rollup/rollup-plugin-node-resolve



